### PR TITLE
(fix): move review panel for subcontractor and monthly invoice project to the top of the review tab

### DIFF
--- a/axelor-business-project/src/main/resources/views/Project.xml
+++ b/axelor-business-project/src/main/resources/views/Project.xml
@@ -372,39 +372,6 @@
           </field>
         </panel>
 
-        <panel name="expenseDataReviewPanel" title="Expense lines review" colSpan="12">
-          <panel-dashlet title="" name="expenseLineReview"
-            action="mgm-action-view-project-expense-line-review" canNew="false" canEdit="false"
-            canSearch="true" colSpan="12"/>
-
-          <field name="$netAmountTotal" title="Net amount total" readonly="true" depends="id"
-            colSpan="3">
-            <viewer depends="$netAmountTotal"><![CDATA[
-      <span style="color: {{ record.$netAmountTotal ? (record.$netAmountTotal == 0 ? 'red' : 'inherit') : 'red' }}">
-        {{ record.$netAmountTotal || '0' }} €
-      </span>
-    ]]></viewer>
-          </field>
-
-          <field name="$netAmountCharges" title="Net amount charges" readonly="true"
-            depends="id" colSpan="3">
-            <viewer depends="$netAmountCharges"><![CDATA[
-      <span style="color: {{ record.$netAmountCharges ? (record.$netAmountCharges == 0 ? 'red' : 'inherit') : 'red' }}">
-        {{ record.$netAmountCharges || '0' }} €
-      </span>
-    ]]></viewer>
-          </field>
-
-          <field name="$netAmountToInvoice" title="Net amount to invoice" readonly="true"
-            depends="id" colSpan="3">
-            <viewer depends="$netAmountToInvoice"><![CDATA[
-      <span style="color: {{ record.$netAmountToInvoice ? (record.$netAmountToInvoice == 0 ? 'red' : 'inherit') : 'red' }}">
-        {{ record.$netAmountToInvoice || '0' }} €
-      </span>
-    ]]></viewer>
-          </field>
-        </panel>
-
         <panel name="invoicingDataLineReviewPanel" title="Invoicing data review" colSpan="12"
           hidden="true">
           <panel-dashlet name="subcontractorProjectTaskReviewDashlet" title=""
@@ -440,6 +407,39 @@
             <viewer depends="$totalHoursReported"><![CDATA[
       <span style="color: {{ record.$totalHoursToBill ? (record.$totalHoursToBill == 0 ? 'red' : 'inherit') : 'red' }}">
         {{ record.$totalHoursToBill || '0' }}
+      </span>
+    ]]></viewer>
+          </field>
+        </panel>
+
+        <panel name="expenseDataReviewPanel" title="Expense lines review" colSpan="12">
+          <panel-dashlet title="" name="expenseLineReview"
+            action="mgm-action-view-project-expense-line-review" canNew="false" canEdit="false"
+            canSearch="true" colSpan="12"/>
+
+          <field name="$netAmountTotal" title="Net amount total" readonly="true" depends="id"
+            colSpan="3">
+            <viewer depends="$netAmountTotal"><![CDATA[
+      <span style="color: {{ record.$netAmountTotal ? (record.$netAmountTotal == 0 ? 'red' : 'inherit') : 'red' }}">
+        {{ record.$netAmountTotal || '0' }} €
+      </span>
+    ]]></viewer>
+          </field>
+
+          <field name="$netAmountCharges" title="Net amount charges" readonly="true"
+            depends="id" colSpan="3">
+            <viewer depends="$netAmountCharges"><![CDATA[
+      <span style="color: {{ record.$netAmountCharges ? (record.$netAmountCharges == 0 ? 'red' : 'inherit') : 'red' }}">
+        {{ record.$netAmountCharges || '0' }} €
+      </span>
+    ]]></viewer>
+          </field>
+
+          <field name="$netAmountToInvoice" title="Net amount to invoice" readonly="true"
+            depends="id" colSpan="3">
+            <viewer depends="$netAmountToInvoice"><![CDATA[
+      <span style="color: {{ record.$netAmountToInvoice ? (record.$netAmountToInvoice == 0 ? 'red' : 'inherit') : 'red' }}">
+        {{ record.$netAmountToInvoice || '0' }} €
       </span>
     ]]></viewer>
           </field>


### PR DESCRIPTION
## Summary
Briefly describe the `"why"` and `"what"`.
For consistency of the order of the reviewal panels based on the order of the panel tabs of the project form, moved the review panel for the subcontractor and monthlhly invoice tab to the top before the expense review panel.

## Changes
Mention all the changes made.
- **views**: Moved the Monthly invoice and subcontractor project tasks review panel to the top of the review and confirmation panel of the project form

## How to Test
Give some steps to test the changes.
1. Open a Subcontractor project or a Monthly Invoice project, navigate to the review and confirmation tab and validate that the `Invoicing data review` panel comes first followed by the expense review then the project extra expense review

## Related Tickets
Fixes #

---

## Developer Checklist
- [ ] **Code Style:** My code follows the project's naming conventions and formatting rules.
- [ ] **Local Build:** I have run `./gradlew clean build` at the root/parent project and the project builds without errors.
- [ ] **Testing:** I have tested these changes manually (or added unit tests) and verified they work as intended.
- [ ] **Up-to-Date:** My branch is based on the latest changes of the `mgm-develop` branch.
- [ ] **No Conflicts:** I have resolved any merge conflicts with the target branch.